### PR TITLE
add the feedback api to collect demo/example usage.

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"encoding/json"
 
 	"github.com/urfave/negroni"
 )
@@ -53,6 +54,47 @@ func main() {
 		_, err = db.Exec("INSERT INTO Usage(uid, content, type) VALUES($1, $2, 0)", uid, content)
 		e(err)
 		res.Write([]byte(*ver))
+	})
+	mux.HandleFunc("/feedback", func(res http.ResponseWriter, req *http.Request) {
+		var uid int64
+		const cookieName = "paddle_stat"
+		c, err := req.Cookie(cookieName)
+		if err != nil { // First time to use Paddle.
+			err = db.QueryRow("SELECT NEXTVAL('UID')").Scan(&uid)
+			e(err)
+			encoded, err := secureCookie.Encode(cookieName, uid)
+			e(err)
+			http.SetCookie(res, &http.Cookie{
+				Name:  cookieName,
+				Value: encoded,
+				Path:  "/feedback",
+			})
+		} else { // Parse cookie to get uid
+			e(secureCookie.Decode(cookieName, c.Value, &uid))
+		}
+		req.ParseForm()
+		keys := []string {
+			"system_time", "paddle_version", "github_user", "job_name",
+			"duration", "exit_code",
+		}
+		content_obj := map[string]string {}
+		for i := 0; i < len(keys); i++ {
+			key := keys[i]
+			val := req.Form.Get(key)
+			if key != "" {
+				content_obj[key] = val
+			}
+		}
+
+		content, err := json.Marshal(content_obj)
+		//content, err := json.Marshal(req.Form)
+		e(err)
+		fmt.Println("The uid:", uid)
+		fmt.Println("content:", string(content))
+
+		_, err = db.Exec("INSERT INTO Usage(uid, content, type) VALUES($1, $2, 1)", uid, content)
+		e(err)
+		res.Write(content)
 	})
 	n.UseHandler(mux)
 	fmt.Println("listen http on ", *addr)


### PR DESCRIPTION
add the api named "/feedback", to upload demo / example usage.

it looks similar to the "/version" api, but the json-string is created at server side, not client side. 